### PR TITLE
data/parsetrigrams.cpp: ensure the output is deterministic

### DIFF
--- a/data/parsetrigrams.cpp
+++ b/data/parsetrigrams.cpp
@@ -1,7 +1,9 @@
 /**
  * parsetrigrams.cpp
  *
- * Parse a set of trigram files into a QHash, and serialize to stdout.
+ * Parse a set of trigram files into a QMap, and serialize to stdout.
+ * Note: we allow this data to be read into QHash. We use QMap here
+ * to get deterministic output from run to run.
  *
  * SPDX-FileCopyrightText: 2006 Jacob Rideout <kde@jacobrideout.net>
  *
@@ -11,7 +13,7 @@
 #include <QDataStream>
 #include <QDir>
 #include <QFile>
-#include <QHash>
+#include <QMap>
 #include <QRegularExpression>
 #include <QString>
 #include <QTextStream>
@@ -29,7 +31,7 @@ int main(int argc, char **argv)
     QString path = QLatin1String(argv[1]);
     QDir td(path);
 
-    QHash<QString, QHash<QString, int>> models;
+    QMap<QString, QMap<QString, int>> models;
 
     const QRegularExpression rx(QStringLiteral("(?:.{3})\\s+(.*)"));
     const QStringList files = td.entryList(QDir::Files);


### PR DESCRIPTION
Noticed non-deterministic binary contents when built sonnet
on NixOS. There rebuild test found out that `parsetrigrams`
generates non-deterministic output of trigrams from run to
run.

This happens because `parsetrigrams` uses `QHash` traversal
order to store key/value pairs in resources section of
`lib/libKF5SonnetCore.so.5.85.0` output binary.

The change uses QMap to serialize trigrams and keeps QHash to
deserialize them (both QMap and QHash have compatible serialization
format:

    [ u32(elem_count) | <key><value> <key><value>... ]

Tested the change to produce deterministic output.